### PR TITLE
Extends RebillyRequest on AddressInfo

### DIFF
--- a/lib/RebillyAddressInfo.php
+++ b/lib/RebillyAddressInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-class RebillyAddressInfo
+class RebillyAddressInfo extends RebillyRequest
 {
     /**
      * @var string $firstName customer's first name
@@ -46,4 +46,14 @@ class RebillyAddressInfo
      * @var string $postCode customer postal code
      */
     public $postalCode;
+
+    /**
+     * Return all the property of this class
+     * @param $class
+     * @return array
+     */
+    public function getPublicProperties($class)
+    {
+        return get_object_vars($class);
+    }
 }


### PR DESCRIPTION
This is the reason why create payment card doesn't work in prod. RebillyAddressInfo need to extends from RebillyRequest to use `public function setAttributes($attributes)` which is used here: https://github.com/netmedialtd/app_rebillyx/blob/development/frontend/controllers/CustomerController.php#L185-L186
