### PR TITLE
add fingerprint as blacklist type

### DIFF
--- a/src/Entities/Blacklist.php
+++ b/src/Entities/Blacklist.php
@@ -38,7 +38,7 @@ final class Blacklist extends Entity
      */
     public static function types()
     {
-        return ['paymentCard', 'customerId', 'email', 'ipAddress', 'bin', 'country'];
+        return ['paymentCard', 'customerId', 'email', 'ipAddress', 'bin', 'country', 'fingerprint'];
     }
 
     /**


### PR DESCRIPTION
We've added fingerprints as a blacklist type in the service.  This change allows developers who use the SDK to take advantage of the new type.