### PR TITLE
fixed websiteId and customerId attribute names in Payment.php

### DIFF
--- a/src/Entities/Payment.php
+++ b/src/Entities/Payment.php
@@ -92,7 +92,7 @@ final class Payment extends Entity
      */
     public function getWebsiteId()
     {
-        return $this->getAttribute('website');
+        return $this->getAttribute('websiteId');
     }
 
     /**
@@ -102,7 +102,7 @@ final class Payment extends Entity
      */
     public function setWebsiteId($value)
     {
-        return $this->setAttribute('website', $value);
+        return $this->setAttribute('websiteId', $value);
     }
 
     /**
@@ -110,7 +110,7 @@ final class Payment extends Entity
      */
     public function getCustomerId()
     {
-        return $this->getAttribute('customer');
+        return $this->getAttribute('customerId');
     }
 
     /**
@@ -120,7 +120,7 @@ final class Payment extends Entity
      */
     public function setCustomerId($value)
     {
-        return $this->setAttribute('customer', $value);
+        return $this->setAttribute('customerId', $value);
     }
 
     /**


### PR DESCRIPTION
Needed to fix these attribute names in order for the "create payment" API method to work correctly.