### PR TITLE
update post endpoint for cancel

### DIFF
--- a/src/Services/PaymentService.php
+++ b/src/Services/PaymentService.php
@@ -122,6 +122,6 @@ final class PaymentService extends Service
      */
     public function cancel($paymentId)
     {
-        return $this->client()->post([], 'payments/{paymentId}/cancel', ['paymentId' => $paymentId]);
+        return $this->client()->post([], 'queue/payments/{paymentId}/cancel', ['paymentId' => $paymentId]);
     }
 }


### PR DESCRIPTION
A payment in the queue can be canceled.  A payment that has already been handled cannot.