### PR TITLE
Add richDescription to plans

### DIFF
--- a/src/Entities/Plan.php
+++ b/src/Entities/Plan.php
@@ -22,6 +22,7 @@ use Rebilly\Rest\Entity;
  *   "name"
  *   "currency"
  *   "description"
+ *   "richDescription"
  *   "recurringAmount"
  *   "recurringPeriodUnit"
  *   "recurringPeriodLength"
@@ -97,6 +98,24 @@ final class Plan extends Entity
     public function setDescription($value)
     {
         return $this->setAttribute('description', $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getRichDescription()
+    {
+        return $this->getAttribute('richDescription');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setRichDescription($value)
+    {
+        return $this->setAttribute('richDescription', $value);
     }
 
     /**

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -703,6 +703,7 @@ class ApiTest extends TestCase
             case 'path':
                 return $faker->words;
             case 'description':
+            case 'richDescription':
                 return $faker->sentences;
             case 'pan':
                 return $faker->creditCardNumber;


### PR DESCRIPTION
To reflect the addition of `richDescription` to plans in the Rebilly API. This field supports HTML content to help merchants display rich content related to a plan via the layout or plan API resource.