### PR TITLE
Preparing version 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ matrix:
   include:
     - php: 5.5
     - php: 5.6
+    - php: 7
       env:
         - EXECUTE_COVERAGE=true
         - EXECUTE_CS_CHECK=true
-    - php: 7
     - php: hhvm
   allow_failures:
+    - php: 5.5
     - php: hhvm
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and other best-practices for defining dependencies at [getcomposer.org](http://g
 
 ## Requirements
 
-* PHP 5.5+ (tested with 5.5, 5.6, 7.0). We recommend you use PHP 7.0.
+* PHP 5.6+. We recommend you use PHP 7.0.
 * CURL (verify peer requires a root certificate authority -- if you have not configured php curl to use one, and your system libs aren't linked to one, you may need to do a [manual configuration](http://stackoverflow.com/questions/17478283/paypal-access-ssl-certificate-unable-to-get-local-issuer-certificate/19149687#19149687) to use the appropriate certificate authority)
 * PHPUnit (tests only)
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "minimum-stability": "stable",
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.6",
     "ext-curl": "*",
     "ext-json": "*",
     "psr/http-message": "~1.0",


### PR DESCRIPTION
New release is not back compatible.

~~Also as [PHP 5.5 reached end of life](http://php.net/supported-versions.php), I think we could require PHP 5.6 for newer version.~~

For this version we will keep PHP 5.5.
