### PR TITLE
Add getBillingContact function to retrieve full contact info

### DIFF
--- a/src/Entities/PaymentCard.php
+++ b/src/Entities/PaymentCard.php
@@ -132,6 +132,14 @@ final class PaymentCard extends Entity
     /**
      * @return string
      */
+    public function getBillingContact()
+    {
+        return $this->getAttribute('billingContact');
+    }
+    
+    /**
+     * @return string
+     */
     public function getBillingContactId()
     {
         return $this->getAttribute('billingContactId');


### PR DESCRIPTION
The full address information appears to still be part of the PaymentCard object, but billingContactId is only available method.  I think this would save another API call to get the rest of the billingContact info.