### PR TITLE
Remove unnecessary attribute "threeDSecureType"

### DIFF
--- a/src/Entities/GatewayAccount.php
+++ b/src/Entities/GatewayAccount.php
@@ -360,24 +360,6 @@ final class GatewayAccount extends Entity
     }
 
     /**
-     * @return null|string
-     */
-    public function getThreeDSecureType()
-    {
-        return $this->getAttribute('threeDSecureType');
-    }
-
-    /**
-     * @param null|string $value
-     *
-     * @return $this
-     */
-    public function setThreeDSecureType($value)
-    {
-        return $this->setAttribute('threeDSecureType', $value);
-    }
-
-    /**
      * @return array
      */
     public function getPaymentCardSchemes()

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -1206,8 +1206,6 @@ class ApiTest extends TestCase
             case 'dynamicDescriptor':
             case 'threeDSecure':
                 return false;
-            case 'threeDSecureType':
-                return 'integrated';
             case 'paymentCardSchemes':
             case 'paymentMethods':
                 return ['Visa'];


### PR DESCRIPTION
This will be merged as soon as the attribute's absence is accounted for in the Rebilly API and app.