### PR TITLE
Add alias to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0.x"
+      "dev-master": "2.0.x"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -47,5 +47,10 @@
     "test": "phpunit",
     "cs": "php-cs-fixer fix -vv --dry-run || true",
     "cs-fix": "php-cs-fixer fix -vv || true"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0.x"
+    }
   }
 }


### PR DESCRIPTION
Anyone can now require 2.0.* and it will happily install dev-master.