### PR TITLE
Handle responses with code 204 properly

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -459,6 +459,10 @@ final class Client
             return null;
         }
 
+        if ($response->getStatusCode() === 204) {
+            return null;
+        }
+
         $responseParsers = [
             'application/json' => [$this, 'parseJsonResponseBody'],
             'application/pdf' => [$this, 'parseBinaryResponseBody'],


### PR DESCRIPTION
We have some endpints with method `POST` and response code `204 No Content`, for example `preview/webhooks`.

Right now it causes an exception, because there's no corresponding resource for empty response.

This PR adds check that there's response code `204` and handles it properly.