### PR TITLE
Fix missing import

### DIFF
--- a/src/Entities/PaymentInstruments/BankAccountPaymentInstrument.php
+++ b/src/Entities/PaymentInstruments/BankAccountPaymentInstrument.php
@@ -11,6 +11,7 @@
 
 namespace Rebilly\Entities\PaymentInstruments;
 
+use DomainException;
 use Rebilly\Entities\PaymentInstrument;
 use Rebilly\Entities\PaymentMethod;
 


### PR DESCRIPTION
It seems that class _BankAccountPaymentInstrument_ is not used anywhere in the code yet, but I've found that there is missing exception import. So, I'm not sure if this fix is necessary for now.