### PR TITLE
Improve report message of validation error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -361,19 +361,10 @@ final class Client
             $content = json_decode($response->getBody()->getContents(), true);
 
             if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
-                foreach ($content['invalidFields'] as $field => &$errors) {
-                    if (is_array($errors)) {
-                        foreach ($errors as &$error) {
-                            $error = $error['message'] ?? '';
-                        }
-                    }
-                }
-                throw new Http\Exception\DataValidationException($content['invalidFields'], $content['details'] ?? []);
+                throw new Http\Exception\DataValidationException($content);
             }
 
-            $content = $content['details'] ?? [];
-
-            throw new Http\Exception\UnprocessableEntityException($content);
+            throw new Http\Exception\UnprocessableEntityException($content['details'] ?? []);
         }
 
         if ($response->getStatusCode() === 429) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -359,7 +359,19 @@ final class Client
 
         if ($response->getStatusCode() === 422) {
             $content = json_decode($response->getBody()->getContents(), true);
-            $content = $content['details'] ?? [];
+
+            if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
+                foreach ($content['invalidFields'] as $field => &$errors) {
+                    if (is_array($errors)) {
+                        foreach ($errors as &$error) {
+                            $error = $error['message'] ?? '';
+                        }
+                    }
+                }
+                $content = $content['invalidFields'];
+            } else {
+                $content = $content['details'] ?? [];
+            }
 
             throw new Http\Exception\UnprocessableEntityException($content);
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -360,11 +360,7 @@ final class Client
         if ($response->getStatusCode() === 422) {
             $content = json_decode($response->getBody()->getContents(), true);
 
-            if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
-                throw new Http\Exception\DataValidationException($content);
-            }
-
-            throw new Http\Exception\UnprocessableEntityException($content['details'] ?? []);
+            throw new Http\Exception\DataValidationException($content);
         }
 
         if ($response->getStatusCode() === 429) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -360,7 +360,7 @@ final class Client
         if ($response->getStatusCode() === 422) {
             $content = json_decode($response->getBody()->getContents(), true);
 
-            throw new Http\Exception\DataValidationException($content);
+            throw new Http\Exception\DataValidationException($content ?? []);
         }
 
         if ($response->getStatusCode() === 429) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -368,10 +368,10 @@ final class Client
                         }
                     }
                 }
-                $content = $content['invalidFields'];
-            } else {
-                $content = $content['details'] ?? [];
+                throw new Http\Exception\DataValidationException($content['invalidFields'], $content['details'] ?? []);
             }
+
+            $content = $content['details'] ?? [];
 
             throw new Http\Exception\UnprocessableEntityException($content);
         }

--- a/src/Http/Exception/DataValidationException.php
+++ b/src/Http/Exception/DataValidationException.php
@@ -23,13 +23,6 @@ final class DataValidationException extends UnprocessableEntityException
     public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
     {
         if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
-            foreach ($content['invalidFields'] as $field => &$errors) {
-                if (is_array($errors)) {
-                    foreach ($errors as &$error) {
-                        $error = $error['message'] ?? '';
-                    }
-                }
-            }
             $this->validationErrors = $content['invalidFields'];
         }
 

--- a/src/Http/Exception/DataValidationException.php
+++ b/src/Http/Exception/DataValidationException.php
@@ -15,16 +15,25 @@ use Exception;
 
 /**
  * Class DataValidationException.
- *
  */
 final class DataValidationException extends UnprocessableEntityException
 {
     private $validationErrors = [];
 
-    public function __construct(array $errors = [], array $details = [], $message = '', $code = 0, Exception $previous = null)
+    public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
     {
-        $this->validationErrors = $errors;
-        parent::__construct($details, $message ?: 'Data Validation Failed.', $code, $previous);
+        if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
+            foreach ($content['invalidFields'] as $field => &$errors) {
+                if (is_array($errors)) {
+                    foreach ($errors as &$error) {
+                        $error = $error['message'] ?? '';
+                    }
+                }
+            }
+            $this->validationErrors = $content['invalidFields'];
+        }
+
+        parent::__construct($content['details'] ?? [], $message ?: 'Data Validation Failed.', $code, $previous);
     }
 
     /**

--- a/src/Http/Exception/DataValidationException.php
+++ b/src/Http/Exception/DataValidationException.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This source file is proprietary and part of Rebilly.
+ *
+ * (c) Rebilly SRL
+ *     Rebilly Ltd.
+ *     Rebilly Inc.
+ *
+ * @see https://www.rebilly.com
+ */
+
+namespace Rebilly\Http\Exception;
+
+use Exception;
+
+/**
+ * Class DataValidationException.
+ *
+ */
+final class DataValidationException extends UnprocessableEntityException
+{
+    private $validationErrors = [];
+
+    public function __construct(array $errors = [], array $details = [], $message = '', $code = 0, Exception $previous = null)
+    {
+        $this->validationErrors = $errors;
+        parent::__construct($details, $message ?: 'Data Validation Failed.', $code, $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidationErrors()
+    {
+        return $this->validationErrors;
+    }
+}

--- a/src/Http/Exception/UnprocessableEntityException.php
+++ b/src/Http/Exception/UnprocessableEntityException.php
@@ -14,8 +14,8 @@ namespace Rebilly\Http\Exception;
 use Exception;
 
 /**
+ * @deprecated
  * Class UnprocessableEntityException.
- *
  */
 class UnprocessableEntityException extends ClientException
 {

--- a/src/Http/Exception/UnprocessableEntityException.php
+++ b/src/Http/Exception/UnprocessableEntityException.php
@@ -17,7 +17,7 @@ use Exception;
  * Class UnprocessableEntityException.
  *
  */
-final class UnprocessableEntityException extends ClientException
+class UnprocessableEntityException extends ClientException
 {
     private $errors = [];
 

--- a/tests/Http/ExceptionTest.php
+++ b/tests/Http/ExceptionTest.php
@@ -48,6 +48,7 @@ class ExceptionTest extends TestCase
 
         $exception = new DataValidationException($content);
 
+        self::assertInstanceOf(UnprocessableEntityException::class, $exception);
         self::assertSame(['Coupon Code must exist'], $exception->getErrors());
         self::assertSame(['couponIds.0' => ['Coupon Code must exist']], $exception->getValidationErrors());
         self::assertSame('Data Validation Failed.', $exception->getMessage());

--- a/tests/Http/ExceptionTest.php
+++ b/tests/Http/ExceptionTest.php
@@ -13,6 +13,7 @@ namespace Rebilly\Tests\Http;
 
 use Rebilly\Http\Exception\DataValidationException;
 use Rebilly\Http\Exception\TooManyRequestsException;
+use Rebilly\Http\Exception\UnprocessableEntityException;
 use Rebilly\Tests\TestCase;
 
 /**

--- a/tests/Http/ExceptionTest.php
+++ b/tests/Http/ExceptionTest.php
@@ -11,6 +11,7 @@
 
 namespace Rebilly\Tests\Http;
 
+use Rebilly\Http\Exception\DataValidationException;
 use Rebilly\Http\Exception\TooManyRequestsException;
 use Rebilly\Tests\TestCase;
 
@@ -35,5 +36,21 @@ class ExceptionTest extends TestCase
         self::assertSame($rateLimit, $exception->getRateLimit());
         self::assertSame($message, $exception->getMessage());
         self::assertSame($code, $exception->getCode());
+    }
+
+    /**
+     * @test
+     */
+    public function dataValidationExceptionSupportsBC()
+    {
+        $data = '{"invalidFields":{"couponIds.0":[{"message":"Coupon Code must exist"}]},"details":["Coupon Code must exist"]}';
+        $content = json_decode($data, true);
+
+        $exception = new DataValidationException($content);
+
+        self::assertSame(['Coupon Code must exist'], $exception->getErrors());
+        self::assertSame(['couponIds.0' => ['Coupon Code must exist']], $exception->getValidationErrors());
+        self::assertSame('Data Validation Failed.', $exception->getMessage());
+        self::assertSame(422, $exception->getStatusCode());
     }
 }

--- a/tests/Http/ExceptionTest.php
+++ b/tests/Http/ExceptionTest.php
@@ -51,7 +51,7 @@ class ExceptionTest extends TestCase
 
         self::assertInstanceOf(UnprocessableEntityException::class, $exception);
         self::assertSame(['Coupon Code must exist'], $exception->getErrors());
-        self::assertSame(['couponIds.0' => ['Coupon Code must exist']], $exception->getValidationErrors());
+        self::assertSame(['couponIds.0' => [['message' => 'Coupon Code must exist']]], $exception->getValidationErrors());
         self::assertSame('Data Validation Failed.', $exception->getMessage());
         self::assertSame(422, $exception->getStatusCode());
     }


### PR DESCRIPTION
In case of  `invalidFields` exists  will be better to use this field instead of just `details`. Because this error message contains field name and array of errors.  But for BC we need extend `UnprocessableEntityException` as `DataValidationException` 

API output:  
`{"invalidFields":{"couponIds.0":["Coupon Code must exist"]},"title":"The request is invalid","status":422,"error":"Data Validation Failed.","details":["Coupon Code must exist"],....`