### PR TITLE
Add dueTimeShift to billingAnchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Security - in case of vulnerabilities.
 - [x] Added `dueTime` to `InvoiceService::issue()` 
 - [x] Added new properties to `Transaction`: `requestAmount`, `requestCurrency`, `purchaseAmount`, `purchaseCurrency`, `isProcessedOutside`
 - [x] Added field `additionalCriteria` into `GatewayAccount` object
+- [x] Added field `dueTimeShift` into `BillingAnchor` object
 
 ### Deprecated
 - [x] Deprecated `Transaction` entity method: `getPaymentCardId`

--- a/src/Entities/Subscriptions/BillingAnchor.php
+++ b/src/Entities/Subscriptions/BillingAnchor.php
@@ -12,6 +12,7 @@
 namespace Rebilly\Entities\Subscriptions;
 
 use Rebilly\Entities\PaymentRetryInstructions\ScheduleInstruction;
+use Rebilly\Entities\PaymentRetryInstructions\ScheduleInstructionTypes\DateIntervalType;
 use Rebilly\Rest\Resource;
 
 final class BillingAnchor extends Resource
@@ -42,5 +43,33 @@ final class BillingAnchor extends Resource
     public function createBillingAnchorInstruction(array $data)
     {
         return ScheduleInstruction::createFromData($data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasDueTimeShift()
+    {
+        return $this->getAttribute('dueTimeShift') instanceof DateIntervalType;
+    }
+
+    /**
+     * @return DateIntervalType
+     */
+    public function getDueTimeShift()
+    {
+        return $this->getAttribute('dueTimeShift');
+    }
+
+    public function setDueTimeShift($value)
+    {
+        return $this->setAttribute('dueTimeShift', $value);
+    }
+
+    public function createDueTimeShift(array $data)
+    {
+        $data['method'] = DateIntervalType::DATE_INTERVAL;
+
+        return DateIntervalType::createFromData($data);
     }
 }


### PR DESCRIPTION
Because due time shift settings have been added to subscription API requests and responses, the corresponding changes should be made in SDK entities.