### PR TITLE
Add patch method to TransactionService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Security - in case of vulnerabilities.
 
 ## [Unreleased]
 
+_TBD_
+
+## [2.8.0] 2020-07-02
+
 ### Added
 - [x] Added new **AML API**
 - [x] Added new **Gateway Account Limit API**
@@ -31,6 +35,7 @@ Security - in case of vulnerabilities.
 - [x] Added new methods to `GatewayAccount`: `setDigitalWallets`, `getDigitalWallets`
 - [x] Added new property to `Invoice`: `transactions`
 - [x] Added new property to `Subscription`: `recentInvoice`
+- [x] Added `patch` method to `TransactionService`
 
 ### Deprecated
 - [x] Deprecated `PayPalAccount` method: `getApprovalLink`

--- a/src/Client.php
+++ b/src/Client.php
@@ -97,7 +97,7 @@ final class Client
 
     public const CURRENT_VERSION = 'v2.1';
 
-    public const SDK_VERSION = '2.7.0';
+    public const SDK_VERSION = '2.8.0';
 
     private static $services = [
         'authenticationOptions' => Services\AuthenticationOptionsService::class,

--- a/src/Services/TransactionService.php
+++ b/src/Services/TransactionService.php
@@ -108,4 +108,17 @@ final class TransactionService extends Service
             'transactions'
         );
     }
+
+    /**
+     * @param string $transactionId
+     * @param array|JsonSerializable|Transaction $data
+     *
+     * @throws UnprocessableEntityException The input data does not valid
+     *
+     * @return Transaction
+     */
+    public function patch($transactionId, $data)
+    {
+        return $this->client()->patch($data, 'transactions/{transactionId}', ['transactionId' => $transactionId]);
+    }
 }

--- a/tests/Api/ServiceTest.php
+++ b/tests/Api/ServiceTest.php
@@ -533,6 +533,9 @@ class ServiceTest extends BaseTestCase
 
         $result = $service->cancel('dummy');
         $this->assertInstanceOf(Entities\Transaction::class, $result);
+
+        $result = $service->patch('dummy', []);
+        $this->assertInstanceOf(Entities\Transaction::class, $result);
     }
 
     /**


### PR DESCRIPTION
This PR adds `patch` method to `TransactionService` and increases SDK version to `2.8.0`