### PR TITLE
Add createdTime to Invoice and Plan entities

### DIFF
--- a/src/Entities/Invoice.php
+++ b/src/Entities/Invoice.php
@@ -402,4 +402,12 @@ final class Invoice extends Entity
     {
         return $this->setAttribute('notes', $value);
     }
+
+    /**
+     * @return string
+     */
+    public function getCreatedTime()
+    {
+        return $this->getAttribute('createdTime');
+    }
 }

--- a/src/Entities/Plan.php
+++ b/src/Entities/Plan.php
@@ -262,4 +262,12 @@ final class Plan extends Entity
     {
         return $this->setAttribute('customFields', $value);
     }
+
+    /**
+     * @return string
+     */
+    public function getCreatedTime()
+    {
+        return $this->getAttribute('createdTime');
+    }
 }


### PR DESCRIPTION
There are no way get all items(if you have many thousands or millions ) except than doing shift by createdTime. Invoice and Plan entities has no field createdTime in response body. I added it.