### PR TITLE
Add documentSubtype and fileIds to KycDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,13 @@ Security - in case of vulnerabilities.
 - [x] Added new property to `Customer`: `revision`
 - [x] Added new property to `Invoice`: `revision`
 - [x] Added new property to `Subscription`: `revision`
-  
+- [x] Added new property to `KycDocument`: `documentSubtype`
+- [x] Added new property to `KycDocument`: `fileIds`
+
 ### Changed
 
 - [x] The `Transaction` property `gatewayAccountId` was made writable.
+- [x] The `KycDocument` property `fileId` was made deprecated.
 
 ## [2.11.0] 2021-03-03
 

--- a/src/Entities/KycDocuments/KycDocument.php
+++ b/src/Entities/KycDocuments/KycDocument.php
@@ -23,6 +23,38 @@ final class KycDocument extends Entity
 
     public const TYPE_ADDRESS_PROOF = 'address-proof';
 
+    public const TYPE_FUNDS_PROOF = 'funds-proof';
+
+    public const TYPE_PURCHASE_PROOF = 'purchase-proof';
+
+    public const SUBTYPE_PASSPORT = 'passport';
+
+    public const SUBTYPE_ID_CARD = 'id-card';
+
+    public const SUBTYPE_DRIVER_LICENSE = 'driver-license';
+
+    public const SUBTYPE_BIRTH_CERTIFICATE = 'birth-certificate';
+
+    public const SUBTYPE_UTILITY_BILL = 'utility-bill';
+
+    public const SUBTYPE_RENTAL_RECEIPT = 'rental-receipt';
+
+    public const SUBTYPE_LEASE_AGREEMENT = 'lease-agreement';
+
+    public const SUBTYPE_COPY_CREDIT_CARD = 'copy-credit-card';
+
+    public const SUBTYPE_CREDIT_CARD_STATEMENT = 'credit-card-statement';
+
+    public const SUBTYPE_BANK_STATEMENT = 'bank-statement';
+
+    public const SUBTYPE_INHERITANCE_DOCUMENTATION = 'inheritance-documentation';
+
+    public const SUBTYPE_TAX_RETURN = 'tax-return';
+
+    public const SUBTYPE_SALARY_SLIP = 'salary-slip';
+
+    public const SUBTYPE_SALE_OF_ASSETS = 'sale-of-assets';
+
     public const STATUS_PENDING = 'pending';
 
     public const STATUS_IN_PROGRESS = 'in-progress';
@@ -33,6 +65,8 @@ final class KycDocument extends Entity
 
     public const MSG_BAD_DOCUMENT_TYPE = 'Bad document type provided.';
 
+    public const MSG_BAD_DOCUMENT_SUBTYPE = 'Bad document subtype provided.';
+
     /**
      * @return array
      */
@@ -41,11 +75,37 @@ final class KycDocument extends Entity
         return [
             self::TYPE_IDENTITY_PROOF,
             self::TYPE_ADDRESS_PROOF,
+            self::TYPE_FUNDS_PROOF,
+            self::TYPE_PURCHASE_PROOF,
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public static function allowedSubtypes()
+    {
+        return [
+            self::SUBTYPE_PASSPORT,
+            self::SUBTYPE_ID_CARD,
+            self::SUBTYPE_DRIVER_LICENSE,
+            self::SUBTYPE_BIRTH_CERTIFICATE,
+            self::SUBTYPE_UTILITY_BILL,
+            self::SUBTYPE_RENTAL_RECEIPT,
+            self::SUBTYPE_LEASE_AGREEMENT,
+            self::SUBTYPE_COPY_CREDIT_CARD,
+            self::SUBTYPE_CREDIT_CARD_STATEMENT,
+            self::SUBTYPE_BANK_STATEMENT,
+            self::SUBTYPE_INHERITANCE_DOCUMENTATION,
+            self::SUBTYPE_TAX_RETURN,
+            self::SUBTYPE_SALARY_SLIP,
+            self::SUBTYPE_SALE_OF_ASSETS,
         ];
     }
 
     /**
      * @return string
+     * @deprecated
      */
     public function getFileId()
     {
@@ -56,10 +116,29 @@ final class KycDocument extends Entity
      * @param string $value
      *
      * @return $this
+     * @deprecated
      */
     public function setFileId($value)
     {
-        return $this->setAttribute('fileId', $value);
+        return $this->setFileIds([$value]);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setFileIds($value)
+    {
+        return $this->setAttribute('fileIds', $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileIds()
+    {
+        return $this->getAttribute('fileIds');
     }
 
     /**
@@ -102,6 +181,30 @@ final class KycDocument extends Entity
         }
 
         return $this->setAttribute('documentType', $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocumentSubtype()
+    {
+        return $this->getAttribute('documentSubtype');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setDocumentSubtype($value)
+    {
+        $allowedSubtypes = self::allowedSubtypes();
+
+        if (!in_array($value, $allowedSubtypes, true)) {
+            throw new DomainException(self::MSG_BAD_DOCUMENT_SUBTYPE);
+        }
+
+        return $this->setAttribute('documentSubtype', $value);
     }
 
     /**


### PR DESCRIPTION
- Added new property to `KycDocument`: `documentSubtype`
- Added new property to `KycDocument`: `fileIds`
- The `KycDocument` property `fileId` was made deprecated.
