### PR TITLE
Adjust PaymentInstruction constructor

### DIFF
--- a/src/Entities/Transactions/PaymentInstruction.php
+++ b/src/Entities/Transactions/PaymentInstruction.php
@@ -27,11 +27,7 @@ abstract class PaymentInstruction extends Resource
 
     public function __construct(array $data = [])
     {
-        if (!isset($data[$this->getAttributeName()])) {
-            throw new InvalidArgumentException(sprintf('Attribute %s is required', $this->getAttributeName()));
-        }
-
-        parent::__construct([$this->getAttributeName() => $data[$this->getAttributeName()]]);
+        parent::__construct([$this->getAttributeName() => $data[$this->getAttributeName()] ?? null]);
     }
 
     /**


### PR DESCRIPTION
Previously there was no way to create a payment instruction and assign token via setter, it's now possible both ways:


```
$paymentInstruction = new Rebilly\Entities\Transactions\PaymentInstructions\PaymentTokenInstruction(['token' => 'payment-token']);
```

```
$paymentInstruction = new Rebilly\Entities\Transactions\PaymentInstructions\PaymentTokenInstruction();
$paymentInstruction->setToken('payment-token');
```