### PR TITLE
Fix setting Restrictions on a Coupon Redemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,17 @@ Security - in case of vulnerabilities.
 
 ## [Unreleased]
 
-Added
+### Added
 
 - [x] Added new property to `Address`: `jobTitle`
 
+### Fixed
+
+- [x] Fixed setting `Restrictions` on `Redemption` 
+
 ## [2.15.0] 2022-02-25
 
-Added
+### Added
  
 - [x] Added **Shipping Rates API**.
 - [x] Added `TransactionService::readyToPay()` method.

--- a/src/Entities/Coupons/Redemption.php
+++ b/src/Entities/Coupons/Redemption.php
@@ -86,7 +86,7 @@ final class Redemption extends Entity
     }
 
     /**
-     * @param array $restrictions
+     * @param array|Restriction[] $restrictions
      *
      * @throws DomainException
      *
@@ -105,8 +105,16 @@ final class Redemption extends Entity
     public function createAdditionalRestrictions(array $data)
     {
         return array_map(
-            function (array $values) {
-                return Restriction::createFromData($values);
+            function ($restriction) {
+                if ($restriction instanceof Restriction) {
+                    return $restriction;
+                }
+
+                if (!is_array($restriction)) {
+                    throw new DomainException('Incorrect restriction - it must be an array or instance of Restriction.');
+                }
+
+                return Restriction::createFromData($restriction);
             },
             $data
         );

--- a/tests/Entities/Coupons/RedemptionTest.php
+++ b/tests/Entities/Coupons/RedemptionTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This source file is proprietary and part of Rebilly.
+ *
+ * (c) Rebilly SRL
+ *     Rebilly Ltd.
+ *     Rebilly Inc.
+ *
+ * @see https://www.rebilly.com
+ */
+
+declare(strict_types=1);
+
+namespace Rebilly\Tests\Entities\Coupons;
+
+use Rebilly\Entities\Coupons\Redemption;
+use Rebilly\Entities\Coupons\Restriction;
+use Rebilly\Tests\TestCase;
+
+final class RedemptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function redeemWithRestrictionViaCreateData(): void
+    {
+        $incomingRestrictions = Restriction::createFromData(
+            [
+                'type' => Restriction::TYPE_DISCOUNTS_PER_REDEMPTION,
+                'quantity' => 2,
+            ]
+        );
+
+        $redemption = new Redemption(
+            [
+                'couponId' => 'coupon-1',
+                'customerId' => 'customer-1',
+            ]
+        );
+
+        $redemption->setAdditionalRestrictions([$incomingRestrictions]);
+        self::assertRedemptionRestrictions($redemption);
+    }
+
+    /**
+     * @test
+     */
+    public function redeemWithRestrictionViaArray(): void
+    {
+        $incomingRestrictions = [
+            'type' => Restriction::TYPE_DISCOUNTS_PER_REDEMPTION,
+            'quantity' => 2,
+        ];
+
+        $redemption = new Redemption(
+            [
+                'couponId' => 'coupon-1',
+                'customerId' => 'customer-1',
+            ]
+        );
+
+        $redemption->setAdditionalRestrictions([$incomingRestrictions]);
+        self::assertRedemptionRestrictions($redemption);
+    }
+
+    private static function assertRedemptionRestrictions(Redemption $redemption): void
+    {
+        self::assertSame('customer-1', $redemption->getCustomerId());
+        /** @var Restriction[] $restrictions */
+        $restrictions = $redemption->getAdditionalRestrictions();
+        self::assertCount(1, $restrictions);
+        self::assertSame(Restriction::TYPE_DISCOUNTS_PER_REDEMPTION, $restrictions[0]->getType());
+    }
+}


### PR DESCRIPTION
Fix the handling of setting restrictions on a Redemption. It now behaves like setting Restrictions on the initial Coupon, making it able to handle an array of associative arrays defining Restrictions, or an array of instantiated Restrictions.