### PR TITLE
Fix InvoiceService methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ _TBD_
 
 ### Fixed
 
-- [x] Fix `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)
-- [x] Fix `InvoiceService::search` method PHPDoc block
+- [x] Fixed `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)
+- [x] Fixed `InvoiceService::search` method PHPDoc block
 
 ## [2.23.0] 2023-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,11 @@ Security - in case of vulnerabilities.
 
 _TBD_
 
-## [2.24.0] 2023-07-19
+## [2.23.1] 2023-07-20
 
 ### Fixed
 
 - [x] Fixed `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)
-- [x] Fixed `InvoiceService::search` method PHPDoc block
 
 ## [2.23.0] 2023-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _TBD_
 ### Fixed
 
 - [x] Fix `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)
+- [x] Fix `InvoiceService::search` method PHPDoc block
 
 ## [2.23.0] 2023-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Security - in case of vulnerabilities.
 
 _TBD_
 
+## [2.24.0] 2023-07-19
+
+### Fixed
+
+- [x] Fix `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)
+
 ## [2.23.0] 2023-07-04
 
 ### Fixed

--- a/src/Client.php
+++ b/src/Client.php
@@ -105,7 +105,7 @@ final class Client
      */
     public const CURRENT_VERSION = 'v2.1';
 
-    public const SDK_VERSION = '2.24.0';
+    public const SDK_VERSION = '2.23.1';
 
     private static $services = [
         'authenticationOptions' => Services\AuthenticationOptionsService::class,

--- a/src/Client.php
+++ b/src/Client.php
@@ -105,7 +105,7 @@ final class Client
      */
     public const CURRENT_VERSION = 'v2.1';
 
-    public const SDK_VERSION = '2.23.0';
+    public const SDK_VERSION = '2.24.0';
 
     private static $services = [
         'authenticationOptions' => Services\AuthenticationOptionsService::class,

--- a/src/Services/InvoiceService.php
+++ b/src/Services/InvoiceService.php
@@ -40,7 +40,7 @@ final class InvoiceService extends Service
     /**
      * @param array|ArrayObject $params
      *
-     * @return Invoice[]|Collection
+     * @return Invoice[]
      */
     public function search($params = [])
     {

--- a/src/Services/InvoiceService.php
+++ b/src/Services/InvoiceService.php
@@ -112,12 +112,12 @@ final class InvoiceService extends Service
 
     /**
      * @param string $invoiceId
-     * @param string $issuedTime
+     * @param string|null $issuedTime
      * @param string|null $dueTime
      *
      * @return Invoice
      */
-    public function issue($invoiceId, $issuedTime, $dueTime = null)
+    public function issue($invoiceId, $issuedTime = null, $dueTime = null)
     {
         return $this->client()->post(
             [

--- a/src/Services/InvoiceService.php
+++ b/src/Services/InvoiceService.php
@@ -40,7 +40,7 @@ final class InvoiceService extends Service
     /**
      * @param array|ArrayObject $params
      *
-     * @return Invoice[]
+     * @return Invoice[]|Collection
      */
     public function search($params = [])
     {


### PR DESCRIPTION
According to the [API-defs](https://api-reference.rebilly.com/tag/Invoices/operation/PostInvoiceIssuance/#!path=issuedTime&t=request) `issuedTime` parameter can be omitted, thus should be nullable.

- [x] Fix `InvoiceService::issue` method signature (make `issuedTime` parameter nullable)