### PR TITLE
Checkout using machine user

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.MACHINE_USER_PAT }}
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v3


### PR DESCRIPTION
Release [PRs](https://github.com/Rebilly/rebilly-php/pull/642) were created by machine user, but commits themselves were using the same token used in `action/checkout`, thus GitHub Action (bot) was used. This lead to actions not being run. [Solution](https://github.com/changesets/action/issues/187#issuecomment-1228413850) was to use machine user token for `action/checkout` as well.