### PR TITLE
fix(sdk-generator): Remove obsolete PDF operation template

### DIFF
--- a/sdk-generator/rebilly-php.config.ts
+++ b/sdk-generator/rebilly-php.config.ts
@@ -223,17 +223,6 @@ const config: GeneratorConfig<PHPCodeGen, AnyStaticContext> = {
                         }
                     }
                     break;
-
-                case 'application/pdf':
-                    templates.push({
-                        name: 'operation-pdf',
-                        context: {
-                            methodName: `${operation.methodName}Pdf`,
-                            accept: response.mimeType,
-                            returnType: 'StreamInterface',
-                        },
-                    });
-                    break;
             }
         }
 
@@ -284,7 +273,6 @@ const config: GeneratorConfig<PHPCodeGen, AnyStaticContext> = {
     partials: {
         'operation-json-collection': 'operation-json-collection.php.handlebars',
         'operation-paginator': 'operation-paginator.php.handlebars',
-        'operation-pdf': 'operation-pdf.php.handlebars',
     },
 
     templateDirs: ['./sdk-generator/templates', '@bundled/php'],

--- a/sdk-generator/templates/operation-pdf.php.handlebars
+++ b/sdk-generator/templates/operation-pdf.php.handlebars
@@ -1,5 +1,0 @@
-{{#>operation-layout}}
-        $response = $this->client->send($request, ['allow_redirects' => ['refer' => true]]);
-
-        return $response->getBody();
-{{/operation-layout}}


### PR DESCRIPTION
## Summary

The latest version of Regenerator adds native support for binary file downloads. This makes the PDF Operation template obsolete and creates a duplicate method in the Api class

<img width="1170" height="826" alt="image" src="https://github.com/user-attachments/assets/c3aa99e8-2d5a-47f1-b156-336d54ffff25" />


This PR thus removes the PDF operation in the Generator configuration