### PR TITLE
fix: PHP 8.4 nullable exception constructors

### DIFF
--- a/.changeset/php84-exception-nullable.md
+++ b/.changeset/php84-exception-nullable.md
@@ -1,0 +1,5 @@
+---
+"@rebilly/client-php": patch
+---
+
+Fix PHP 8.4 deprecations on exception constructors by marking `$previous` as explicitly nullable.

--- a/sdk-generator/templates/static/src/Exception/DataValidationException.php.handlebars
+++ b/sdk-generator/templates/static/src/Exception/DataValidationException.php.handlebars
@@ -10,7 +10,7 @@ final class DataValidationException extends HttpException
 {
     private array $validationErrors = [];
 
-    public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
+    public function __construct(array $content = [], $message = '', $code = 0, ?Exception $previous = null)
     {
         if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
             $this->validationErrors = $content['invalidFields'];

--- a/src/Exception/DataValidationException.php
+++ b/src/Exception/DataValidationException.php
@@ -20,7 +20,7 @@ final class DataValidationException extends HttpException
 {
     private array $validationErrors = [];
 
-    public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
+    public function __construct(array $content = [], $message = '', $code = 0, ?Exception $previous = null)
     {
         if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
             $this->validationErrors = $content['invalidFields'];

--- a/src/Exception/GoneException.php
+++ b/src/Exception/GoneException.php
@@ -18,7 +18,7 @@ use Exception;
 
 final class GoneException extends ClientException
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(410, $message, $code, $previous);
     }

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -20,7 +20,7 @@ class HttpException extends Exception
 {
     private int $statusCode;
 
-    public function __construct($status, $message = '', $code = 0, Exception $previous = null)
+    public function __construct($status, $message = '', $code = 0, ?Exception $previous = null)
     {
         $this->statusCode = (int) $status;
         parent::__construct($message, $code, $previous);

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -18,7 +18,7 @@ use Exception;
 
 final class NotFoundException extends ClientException
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(404, $message, $code, $previous);
     }

--- a/src/Exception/TooManyRequestsException.php
+++ b/src/Exception/TooManyRequestsException.php
@@ -22,7 +22,7 @@ final class TooManyRequestsException extends ClientException
 
     private int $rateLimit;
 
-    public function __construct($retryAfter, $rateLimit = 0, $message = '', $code = 0, Exception $previous = null)
+    public function __construct($retryAfter, $rateLimit = 0, $message = '', $code = 0, ?Exception $previous = null)
     {
         $this->retryAfter = $retryAfter;
         $this->rateLimit = (int) $rateLimit;


### PR DESCRIPTION
## Summary

- Mark `$previous` as `?Exception` on five SDK exception constructors to silence PHP 8.4 implicit-nullable deprecations.
- Update `sdk-generator/templates/static/src/Exception/DataValidationException.php.handlebars` so regen keeps the fix (rebilly-php-specific; other exceptions come from `@bundled/php` in `@rebilly/regenerator`, already fixed in regenerator `0.0.7+`).