### PR TITLE
fix: Make SDK compatible with PHP 8.4 (CI test)

### DIFF
--- a/.changeset/swift-lions-listen.md
+++ b/.changeset/swift-lions-listen.md
@@ -1,0 +1,5 @@
+---
+"@rebilly/client-php": patch
+---
+
+fix(sdk): Make SDK compatible with PHP 8.4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: "Checkout"
@@ -42,7 +42,7 @@ jobs:
         run: composer install --no-interaction --no-scripts --no-suggest
 
       - name: "Run tests"
-        run: vendor/bin/psalm
+        run: vendor/bin/psalm --php-version=${{ matrix.php-version }}
 
   cs:
     name: "Coding Standards"
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,11 +48,6 @@ jobs:
     name: "Coding Standards"
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
-
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -63,7 +58,7 @@ jobs:
       - name: "Install PHP w/ Extensions"
         uses: rebilly/setup-php@main
         with:
-          php-version: ${{ matrix.php-version }}
+          php-version: '8.0'
           extensions: mbstring, intl, curl, json
           tools: composer:v2
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -48,6 +48,11 @@ jobs:
     name: "Coding Standards"
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.0', '8.1', '8.2']
+
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -58,7 +63,7 @@ jobs:
       - name: "Install PHP w/ Extensions"
         uses: rebilly/setup-php@main
         with:
-          php-version: '8.0'
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl, curl, json
           tools: composer:v2
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -31,6 +31,8 @@ jobs:
         with:
           node-version: "24"
           cache: "npm"
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@rebilly"
           cache-dependency-path: |
             package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rebilly SDK for PHP
 
+
 [![Latest Version on Packagist][ico-version]][link-packagist] 
 [![Software License][ico-license]](LICENSE) 
 [![Total Downloads][ico-downloads]][link-downloads] 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",
-    "vimeo/psalm": "^5.26"
+    "vimeo/psalm": "^5.26 || ^6.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     }
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.23",
-    "vimeo/psalm": "^5.14"
+    "friendsofphp/php-cs-fixer": "^3.64",
+    "vimeo/psalm": "^5.26"
   },
   "autoload-dev": {
     "psr-4": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@changesets/write": "^0.2.3",
-        "@rebilly/regenerator": "^0.0.7",
+        "@rebilly/regenerator": "^0.0.9",
         "ts-node": "^10.9.2"
       }
     },
@@ -913,14 +913,14 @@
       }
     },
     "node_modules/@rebilly/regenerator": {
-      "version": "0.0.7",
-      "resolved": "https://npm.pkg.github.com/download/@rebilly/regenerator/0.0.7/99a07db987d882b770d8ae93da734bc7c8ae2d67",
-      "integrity": "sha512-xjK8Jo1fHgYMPSXGRpfDGPuFkeWfoI4Zoih0/UP5f5q4BW2+UC3MhgHjG6HlBbkOpskBV/QLJM8l/vD0x24Bdg==",
+      "version": "0.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@rebilly/regenerator/0.0.9/aa99de840ff6f9834ddbf839cb9adface8148d13",
+      "integrity": "sha512-3TZm1uUufVrMritaKTCZBODzt3aHe5rh8d/Re5ZWQwegIo4MYorc2QJuaGn3GaWtEJIcYAQI3LYhQgnq2jontw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redocly/openapi-core": "^2.3.1",
-        "es-toolkit": "^1.39.10",
+        "@redocly/openapi-core": "^2.30.0",
+        "es-toolkit": "^1.46.1",
         "handlebars": "^4.7.9",
         "mime-types": "^3.0.2",
         "tsx": "^4.20.3",
@@ -931,13 +931,13 @@
       },
       "engines": {
         "node": ">=15.0.0",
-        "npm": ">=7.0.0"
+        "pnpm": ">=10.16.0"
       }
     },
     "node_modules/@redocly/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.3.tgz",
+      "integrity": "sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -952,9 +952,9 @@
       }
     },
     "node_modules/@redocly/config": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.44.0.tgz",
-      "integrity": "sha512-UHKkWcCNZrGiKBbrQ1CE08ElrOUGm5H97Zn8+wkp80Uu2AT/go5In1sbqvhHxViPYtu1MLdy7qKiifSyOL3W/A==",
+      "version": "0.48.1",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.48.1.tgz",
+      "integrity": "sha512-vq8GM3e0KiglqkwE5Lb9XayrmZY4dHCs21BsvV92yAZN68f1N9cZUuwY1SwnztPbH06dn9uLzubBl/JNfImqfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -962,20 +962,20 @@
       }
     },
     "node_modules/@redocly/openapi-core": {
-      "version": "2.20.4",
-      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.20.4.tgz",
-      "integrity": "sha512-3WZh8dPF6MrxLDbTG4GXtV81EOqHrpMWlOhELWBIICRieMMt/LKcGFuOBRdLEp/KMU2ypwQLKYHrKYCeUNwO3Q==",
+      "version": "2.30.5",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-2.30.5.tgz",
+      "integrity": "sha512-ikljMaow1wX3GoRvLiJvqOq8H3f6XsuMBZqCGmeY0+UPmlnVhrvW8m/gC1vkKcGNvYINUrgi/Z6dBtzQ7854wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@redocly/ajv": "^8.18.0",
-        "@redocly/config": "^0.44.0",
-        "ajv": "npm:@redocly/ajv@8.18.0",
+        "@redocly/ajv": "^8.18.1",
+        "@redocly/config": "^0.48.1",
+        "ajv": "npm:@redocly/ajv@8.18.1",
         "ajv-formats": "^3.0.1",
         "colorette": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "js-yaml": "^4.1.0",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "pluralize": "^8.0.0",
         "yaml-ast-parser": "0.0.43"
       },
@@ -1058,9 +1058,9 @@
     },
     "node_modules/ajv": {
       "name": "@redocly/ajv",
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
+      "integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1304,9 +1304,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
-      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -1412,9 +1412,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -1978,9 +1978,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@changesets/write": "^0.2.3",
-    "@rebilly/regenerator": "^0.0.7",
+    "@rebilly/regenerator": "^0.0.9",
     "ts-node": "^10.9.2"
   },
   "scripts": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,5 +32,6 @@
         <UnusedMethod errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
         <ForbiddenCode errorLevel="suppress"/>
+        <MissingOverrideAttribute errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/sdk-generator/templates/static/psalm.xml.handlebars
+++ b/sdk-generator/templates/static/psalm.xml.handlebars
@@ -32,5 +32,6 @@
         <UnusedMethod errorLevel="suppress"/>
         <PossiblyUnusedReturnValue errorLevel="suppress"/>
         <ForbiddenCode errorLevel="suppress"/>
+        <MissingOverrideAttribute errorLevel="suppress"/>
     </issueHandlers>
 </psalm>

--- a/sdk-generator/templates/static/src/Exception/DataValidationException.php.handlebars
+++ b/sdk-generator/templates/static/src/Exception/DataValidationException.php.handlebars
@@ -10,7 +10,7 @@ final class DataValidationException extends HttpException
 {
     private array $validationErrors = [];
 
-    public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
+    public function __construct(array $content = [], $message = '', $code = 0, ?Exception $previous = null)
     {
         if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
             $this->validationErrors = $content['invalidFields'];

--- a/src/Exception/DataValidationException.php
+++ b/src/Exception/DataValidationException.php
@@ -20,7 +20,7 @@ final class DataValidationException extends HttpException
 {
     private array $validationErrors = [];
 
-    public function __construct(array $content = [], $message = '', $code = 0, Exception $previous = null)
+    public function __construct(array $content = [], $message = '', $code = 0, ?Exception $previous = null)
     {
         if (isset($content['invalidFields']) && is_array($content['invalidFields'])) {
             $this->validationErrors = $content['invalidFields'];

--- a/src/Exception/GoneException.php
+++ b/src/Exception/GoneException.php
@@ -18,7 +18,7 @@ use Exception;
 
 final class GoneException extends ClientException
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(410, $message, $code, $previous);
     }

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -20,7 +20,7 @@ class HttpException extends Exception
 {
     private int $statusCode;
 
-    public function __construct($status, $message = '', $code = 0, Exception $previous = null)
+    public function __construct($status, $message = '', $code = 0, ?Exception $previous = null)
     {
         $this->statusCode = (int) $status;
         parent::__construct($message, $code, $previous);

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -18,7 +18,7 @@ use Exception;
 
 final class NotFoundException extends ClientException
 {
-    public function __construct($message = '', $code = 0, Exception $previous = null)
+    public function __construct($message = '', $code = 0, ?Exception $previous = null)
     {
         parent::__construct(404, $message, $code, $previous);
     }

--- a/src/Exception/TooManyRequestsException.php
+++ b/src/Exception/TooManyRequestsException.php
@@ -22,7 +22,7 @@ final class TooManyRequestsException extends ClientException
 
     private int $rateLimit;
 
-    public function __construct($retryAfter, $rateLimit = 0, $message = '', $code = 0, Exception $previous = null)
+    public function __construct($retryAfter, $rateLimit = 0, $message = '', $code = 0, ?Exception $previous = null)
     {
         $this->retryAfter = $retryAfter;
         $this->rateLimit = (int) $rateLimit;


### PR DESCRIPTION
Test branch copied from `php84-compat` to verify CI required checks.

## CI fix

Restores the **Coding Standards** job matrix (`8.0`, `8.1`, `8.2`) so check names match `main` branch protection (`Coding Standards (8.0)` etc.). The original `php84-compat` branch used a single CS job, which left required checks stuck as "Expected".

Related: #773

Made with [Cursor](https://cursor.com)