### PR TITLE
fix: Remove snapshot carry on auto-update branches

### DIFF
--- a/.changeset/true-doors-open.md
+++ b/.changeset/true-doors-open.md
@@ -1,0 +1,5 @@
+---
+"@rebilly/client-php": patch
+---
+
+fix: Remove snapshot carry on auto-update branches

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -19,16 +19,14 @@ jobs:
           path: 'sdk'
           fetch-depth: 0
 
-      - name: Keep changesets and snapshot from auto-update branch
+      - name: Keep changesets from auto-update branch
         working-directory: ./sdk
         run: |
           mkdir ../carry
           git checkout automations/update-sdk-from-api-definitions || true
           cp .changeset/* ../carry/ 2>/dev/null || true
-          [ -f .openapi-snapshot.yaml ] && cp .openapi-snapshot.yaml ../carry/.openapi-snapshot.yaml || true
           git checkout main || true
           cp ../carry/*.md .changeset/ 2>/dev/null || true
-          [ -f ../carry/.openapi-snapshot.yaml ] && cp ../carry/.openapi-snapshot.yaml .openapi-snapshot.yaml || true
 
       - name: Checkout generator repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The auto-update workflow's "Keep changesets and snapshot" step copied `.openapi-snapshot.yaml` from the auto-update branch back into the workspace before running `oasdiff`. When that branch already held a snapshot updated by an earlier run, the spec diff compared current api-definitions against itself and missed every real change that happened after the snapshot was last advanced.

This PR removes the snapshot carry. Each workflow run now diffs current api-definitions against main's `.openapi-snapshot.yaml`, which only advances when a release ships.
