### PR TITLE
chore: Align state with shipped 3.1.9

### DIFF
--- a/.changeset/spotty-deer-switch.md
+++ b/.changeset/spotty-deer-switch.md
@@ -1,0 +1,3 @@
+---
+"@rebilly/client-php": patch
+---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,78 +1,33 @@
 # @rebilly/client-php
 
-## 4.0.0
-
-### Major Changes
-
-- ### Added
-
-  - Added optional response property `canceledTime` on `Subscription` — `GET /search`, `GET /subscriptions` + 5 more
-  - Added optional response property `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `inputType` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `inputType` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `minimumAge` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `minimumAge` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `placeholder` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `placeholder` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-
-  ### Enum changes
-
-  - Enum value added on request `attribute`: `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Enum value added on response `attribute`: `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-
-  ### Other
-
-  - response-property-min-decreased (20x) — e.g. the `items/oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` respons
-  - request-property-min-decreased (7x) — e.g. the `oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` request prope
-
-- ### Added
-
-  - Added optional response property `canceledTime` on `Subscription` — `GET /search`, `GET /subscriptions` + 5 more
-  - Added optional response property `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `inputType` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `inputType` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `minimumAge` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `minimumAge` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `placeholder` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `placeholder` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-
-  ### Enum changes
-
-  - Enum value added on request `attribute`: `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Enum value added on response `attribute`: `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-
-  ### Other
-
-  - response-property-min-decreased (20x) — e.g. the `items/oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` respons
-  - request-property-min-decreased (7x) — e.g. the `oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` request prope
-
-### Minor Changes
-
-- ### Added
-
-  - Added optional response property `canceledTime` on `Subscription` — `GET /search`, `GET /subscriptions` + 5 more
-  - Added optional response property `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `inputType` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `inputType` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `minimumAge` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `minimumAge` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Added optional response property `placeholder` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
-  - Added optional request property `placeholder` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-
-  ### Enum changes
-
-  - Enum value added on request `attribute`: `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
-  - Enum value added on response `attribute`: `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+## 3.1.9
 
 ### Patch Changes
 
+- ### Added
+
+  - Added optional response property `canceledTime` on `Subscription` — `GET /search`, `GET /subscriptions` + 5 more
+  - Added optional response property `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+  - Added optional request property `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
+  - Added optional response property `inputType` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+  - Added optional request property `inputType` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
+  - Added optional response property `minimumAge` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+  - Added optional request property `minimumAge` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
+  - Added optional response property `placeholder` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+  - Added optional request property `placeholder` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
+
+  ### Enum changes
+
+  - Enum value added on request `attribute`: `contentBlock` — `POST /account-registration-settings`, `PUT /account-registration-settings/{id}`
+  - Enum value added on response `attribute`: `contentBlock` — `GET /account-registration-settings`, `POST /account-registration-settings` + 2 more
+
+  ### Other
+
+  - response-property-min-decreased (20x) — e.g. the `items/oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` response property's minimum was decreased.
+  - request-property-min-decreased (7x) — e.g. the `oneOf[#/components/schemas/OneTimeOrder]/_embedded/website/settings/payoutRequest/pendingPeriodHours` request property's minimum was decreased.
+
 - chore(deps): bump picomatch
 - chore(deps-dev): bump fast-uri
-- chore(deps-dev): bump fast-uri
--
 - fix: Remove snapshot carry on auto-update branches
 
 ## 3.1.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rebilly/client-php",
-  "version": "4.0.0",
+  "version": "3.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rebilly/client-php",
-      "version": "4.0.0",
+      "version": "3.1.9",
       "devDependencies": {
         "@changesets/cli": "^2.26.2",
         "@changesets/write": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rebilly/client-php",
   "private": true,
-  "version": "4.0.0",
+  "version": "3.1.9",
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@changesets/write": "^0.2.3",

--- a/src/Client.php
+++ b/src/Client.php
@@ -42,7 +42,7 @@ final class Client implements GuzzleClientInterface, PsrClientInterface
 
     public const EXPERIMENTAL_BASE = '/experimental';
 
-    public const SDK_VERSION = '4.0.0';
+    public const SDK_VERSION = '3.1.9';
 
     private GuzzleClient $client;
 


### PR DESCRIPTION
The previous release PR merged with `package.json`, `package-lock.json`, `src/Client.php`, and the `CHANGELOG.md` heading bumped to `4.0.0`, but the published packagist version is `3.1.9`.