### PR TITLE
chore: replace @Rebilly/php CODEOWNERS with @Rebilly/devs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # See: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # As soon as a PR is added or a project is published, these teams will be invited for review.
-* @Rebilly/php
+* @Rebilly/devs


### PR DESCRIPTION
Replace `@Rebilly/php` with `@Rebilly/devs` in CODEOWNERS.

Made with [Cursor](https://cursor.com)