### PR TITLE
ci: stop using MACHINE_USER_PAT

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,12 +11,14 @@ jobs:
   generate-and-diff:
     name: Generate SDK and diff vs main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
 
     steps:
       - name: Checkout current ref
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.MACHINE_USER_PAT }}
 
       - name: Checkout main
         uses: actions/checkout@v4
@@ -24,7 +26,6 @@ jobs:
           repository: ${{ github.repository }}
           ref: main
           path: main-sdk
-          token: ${{ secrets.MACHINE_USER_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -41,7 +42,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.MACHINE_USER_PAT }}
+          password: ${{ github.token }}
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,12 +13,23 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
+      - id: sdk-write-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REBILLY_CI_SDK_WRITE_CLIENT_ID }}
+          private-key: ${{ secrets.REBILLY_CI_SDK_WRITE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.MACHINE_USER_PAT }}
+          token: ${{ steps.sdk-write-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -41,4 +52,4 @@ jobs:
           title: 'chore: 🔖 release new version'
           version: npm run version
         env:
-          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_PAT }}
+          GITHUB_TOKEN: ${{ steps.sdk-write-token.outputs.token }}

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,6 +6,10 @@ on:
 jobs:
   generate-sdk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
     steps:
       - name: Checkout api-definitions repo
         uses: actions/checkout@v4
@@ -27,17 +31,6 @@ jobs:
           cp .changeset/* ../carry/ 2>/dev/null || true
           git checkout main || true
           cp ../carry/*.md .changeset/ 2>/dev/null || true
-
-      - name: Checkout generator repo
-        uses: actions/checkout@v4
-        with:
-          token: '${{ secrets.MACHINE_USER_PAT }}'
-          path: 'generator'
-          repository: 'Rebilly/rebilly'
-          sparse-checkout: |
-            backend/php-sdk-generator/remove-fqcns.php
-            backend/php-sdk-generator/remove-unused-models.php
-          sparse-checkout-cone-mode: true
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -87,7 +80,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.MACHINE_USER_PAT }}
+          password: ${{ github.token }}
 
       - name: Install Dependencies
         working-directory: ./sdk
@@ -151,13 +144,21 @@ jobs:
             cat /tmp/changeset-body.md
           } > .changeset/spec-diff.md
 
+      - id: sdk-write-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REBILLY_CI_SDK_WRITE_CLIENT_ID }}
+          private-key: ${{ secrets.REBILLY_CI_SDK_WRITE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Create PR
         id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
           # Path of the checked-out repo where we placed the generated resources
           path: 'sdk'
-          token: ${{ secrets.MACHINE_USER_PAT }}
+          token: ${{ steps.sdk-write-token.outputs.token }}
           title: 'chore: update SDK from api-definitions'
           commit-message: update SDK from api-definitions
           branch: automations/update-sdk-from-api-definitions

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -9,7 +9,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: write
     steps:
       - name: Checkout api-definitions repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Replace `MACHINE_USER_PAT` with `github.token` for GHCR and a repo-scoped SDK write-app token for automation PRs.

Preview workflow dispatched on this branch and passed (GHCR login + generate).