### PR TITLE
fix: update oasdiff to restore SDK generation

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -62,7 +62,7 @@ jobs:
           docker run --rm \
             -v "$PWD/sdk:/sdk" \
             -v "$PWD/api-definitions:/adef" \
-            tufin/oasdiff:v1.18.1 \
+            tufin/oasdiff:v1.30.0 \
             changelog /sdk/.openapi-snapshot.yaml /adef/catalog/all.yaml -f json > /tmp/spec-diff.json
 
       - name: Summarize spec diff


### PR DESCRIPTION
## Summary

- update oasdiff from v1.18.1 to v1.30.0
- avoid the nil-pointer panic blocking API definition-driven SDK regeneration

The failure is visible in [this SDK update run](https://github.com/Rebilly/rebilly-php/actions/runs/33010913847). The upstream panic was fixed in oasdiff v1.21.0.

## Test plan

- [x] Run `git diff --check`
- [ ] Merge and rerun `Updates SDK based on api-definitions`
- [ ] Confirm the generated SDK update PR removes the obsolete payout request cancellation operation
